### PR TITLE
README: Use correct path for initialization

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -36,6 +36,7 @@
         "mgmt",
         "nanos",
         "nicautoconfig",
+        "nlb",
         "oneshot",
         "Pastebin",
         "payg",

--- a/examples/stateful-nlb-byol/README.md
+++ b/examples/stateful-nlb-byol/README.md
@@ -28,7 +28,7 @@ are:
 1. Clone the example from GitHub
 
    ```shell
-   terraform init --from-module git::https://github.com/f5devcentral/terraform-google-f5-bigip-ha//examples/stateful-nlb
+   terraform init --from-module git::https://github.com/f5devcentral/terraform-google-f5-bigip-ha//examples/stateful-nlb-byol
    ```
 
 1. Create `terraform.tfvars`, or use fixed values in [main.tf](./main.tf)

--- a/examples/stateless-nlb/README.md
+++ b/examples/stateless-nlb/README.md
@@ -23,7 +23,7 @@ disaggregation provided by a passthrough External Network Load Balancer. The cha
 1. Clone the example from GitHub
 
    ```shell
-   terraform init --from-module git::https://github.com/f5devcentral/terraform-google-f5-bigip-ha//examples/stateless-nlb
+   terraform init --from-module git::https://github.com/f5devcentral/terraform-google-f5-bigip-ha//examples/stateless-nlb-byol
    ```
 
 1. Create `terraform.tfvars`, or use fixed values in [main.tf](./main.tf)

--- a/examples/stateless-nlb/README.md
+++ b/examples/stateless-nlb/README.md
@@ -23,7 +23,7 @@ disaggregation provided by a passthrough External Network Load Balancer. The cha
 1. Clone the example from GitHub
 
    ```shell
-   terraform init --from-module git::https://github.com/f5devcentral/terraform-google-f5-bigip-ha//examples/stateless-nlb-byol
+   terraform init --from-module git::https://github.com/f5devcentral/terraform-google-f5-bigip-ha//examples/stateless-nlb
    ```
 
 1. Create `terraform.tfvars`, or use fixed values in [main.tf](./main.tf)


### PR DESCRIPTION
README for stateful-nlb-byol example was using the wrong path in the first step (`terraform init`); this corrects that.